### PR TITLE
feat: 新增分组、链接登录可见

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -74,6 +74,16 @@ spec:
           value: "true"
         - label: 不显示
           value: "false"
+    - $formkit: radio
+      name: show_group_anonymous
+      label: 分组是否登录可见
+      help: 控制此分组是否登录可见
+      value: "false"
+      options:
+        - label: 是
+          value: "true"
+        - label: 否
+          value: "false"
 
 ---
 
@@ -100,3 +110,13 @@ spec:
       name: to_post
       label: 关联的文章
       help: "当有关联的文章时，则跳转到对应文章，而不是直接访问地址。上方的关联文章选择 关联 后有效"
+    - $formkit: radio
+      name: show_link_anonymous
+      label: 链接是否登录可见
+      help: 控制此链接是否登录可见
+      value: "false"
+      options:
+        - label: 是
+          value: "true"
+        - label: 否
+          value: "false"

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,8 @@
         th:replace="~{widgets/search}"
       />
 
-      <th:block th:each="group : ${linkFinder.groupBy()}" th:if="${#annotations.getOrDefault(group, 'show_on_heolink', 'true') == 'true'}">
+      <th:block th:each="group : ${linkFinder.groupBy()}"
+                th:if="${#annotations.getOrDefault(group, 'show_on_heolink', 'true') == 'true' and (#annotations.getOrDefault(group, 'show_group_anonymous', 'false') != 'true' or #annotations.getOrDefault(group, 'show_group_anonymous', 'false') == 'true' and logon)}">
         <div class="link_group" th:if="${#lists.size(group.links) > 0}">
           <div class="link_group_title_content" th:if="${group.spec.displayName != ''}" >
             <i th:class="${#annotations.getOrDefault(group, 'icon', 'ri-archive-stack-fill')}"></i>
@@ -34,7 +35,8 @@
                         shouldLinkToPost = ${to_post_radio == 'true' and to_post != null and to_post != ''},
                         item_url = ${shouldLinkToPost ? postFinder.getByName(to_post).status.permalink : link.spec.url}"
                th:href="${item_url}"
-               th:target="${shouldLinkToPost ? '' : '_blank'}">
+               th:target="${shouldLinkToPost ? '' : '_blank'}"
+               th:if="${(#annotations.getOrDefault(link, 'show_link_anonymous', 'false') != 'true' or #annotations.getOrDefault(link, 'show_link_anonymous', 'false') == 'true' and logon)}">
               <div class="link_group_content_item">
                 <div class="link_group_content_item_logo">
                   <img class="link_group_content_item_logo_img"

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -21,7 +21,7 @@
       <th:block th:replace="${head}" />
     </th:block>
   </head>
-  <body th:style="'background-color: '+${theme.config.style.background_color ?: '#f2f2f2'}">
+  <body th:style="'background-color: '+${theme.config.style.background_color ?: '#f2f2f2'}" th:with="logon = ${#authentication.name != 'anonymousUser'}">
     <section>
       <div class="heolink_site"  th:if="${pluginFinder.available('PluginLinks')}">
         <th:block

--- a/templates/widgets/nav.html
+++ b/templates/widgets/nav.html
@@ -10,7 +10,8 @@
     <img th:src="${site.logo ?: #theme.assets('/images/logo_cover.jpg')}" alt="logo" />
   </a>
   <div class="left_nav_group" id="left_nav_group">
-    <th:block th:each="group : ${linkFinder.groupBy()}" th:if="${#annotations.getOrDefault(group, 'show_on_heolink', 'true') == 'true'}">
+    <th:block th:each="group : ${linkFinder.groupBy()}"
+              th:if="${#annotations.getOrDefault(group, 'show_on_heolink', 'true') == 'true' && (#annotations.getOrDefault(group, 'show_group_anonymous', 'false') != 'true' || #annotations.getOrDefault(group, 'show_group_anonymous', 'false') == 'true' && logon)}">
       <div class="left_nav_item" th:if="${group.spec.displayName != ''}">
         <a class="left_nav_link_group_title" th:data-target="${group.spec.displayName}" href="javascript:void(0)">
           <i th:class="${#annotations.getOrDefault(group, 'icon', 'ri-archive-stack-fill')}"></i>


### PR DESCRIPTION
### feat: 新增分组、链接登录可见
- 安装 `页面静态缓存` 插件时，调整分组和链接时，需要刷新缓存后有效；
- 分组隐藏时，该分组下的所有链接均不显示；
- 分组不隐藏、链接全部隐藏后，该分组不会隐藏，需要设置该分组的登录可见行为。