### PR TITLE
perf：优化设置按钮跳转Url

### DIFF
--- a/templates/widgets/nav.html
+++ b/templates/widgets/nav.html
@@ -32,7 +32,7 @@
     </div>
 
     <div class="footer_console">
-      <a href="/login" target="_blank" title="管理后台">
+      <a th:href="${logon ? '/console' : '/login?redirect_uri=/'}" th:target="${logon ? '_blank' : '_self'}" title="管理后台">
         <i class="ri-settings-4-fill"></i>
       </a>
       <a href="https://github.com/zhheo/halo-theme-heolink" target="_blank" class="theme_info" title="Theme HeoLink by Halo">Theme HeoLink by Halo</a>


### PR DESCRIPTION
### perf：优化设置按钮跳转Url

- 用户未登录时，设置按钮跳转为`/login?redirect_uri=/`，即：登录后返回前台页面并刷新展示隐藏的链接；
- 用户登录时，设置按钮跳转为`/console`，即：打开后台管理页面，而非个人中心页面。

### 已知问题
- `target="_blank"`并未生效，目前均为当前窗口跳转Url，疑似`pjax`导致。