### PR TITLE
fix：修复设置按钮未能按照target方式执行的问题

### DIFF
--- a/templates/widgets/nav.html
+++ b/templates/widgets/nav.html
@@ -32,7 +32,7 @@
     </div>
 
     <div class="footer_console">
-      <a th:href="${logon ? '/console' : '/login?redirect_uri=/'}" th:target="${logon ? '_blank' : '_self'}" title="管理后台">
+      <a th:href="${logon ? '/console' : '/login?redirect_uri=/'}" th:target="${logon ? '_blank' : '_self'}" title="管理后台" data-pjax-state="external">
         <i class="ri-settings-4-fill"></i>
       </a>
       <a href="https://github.com/zhheo/halo-theme-heolink" target="_blank" class="theme_info" title="Theme HeoLink by Halo">Theme HeoLink by Halo</a>


### PR DESCRIPTION
### fix：修复设置按钮未能按照target方式执行的问题
- 用户未登录时，点击按钮将在当前标签页跳转，登录后自动跳转回首页；
- 用于已登录时，点击按钮将在新标签页打开后台管理页面。

注：对`a`标签添加`data-pjax-state="external"`将不会按照`pjax`操作执行，而是按照`target`设置执行跳转方式。